### PR TITLE
add yarn-modern-pnp to update script

### DIFF
--- a/scripts/update-cypress-latest-other.sh
+++ b/scripts/update-cypress-latest-other.sh
@@ -48,6 +48,14 @@ yarn set version latest
 yarn add cypress --dev --exact
 cd ..
 
+# examples/yarn-modern-pnp
+echo
+echo updating examples/yarn-modern-pnp to cypress@latest
+cd yarn-modern-pnp
+yarn set version latest
+yarn add cypress --dev --exact
+cd ..
+
 # examples/basic-pnpm (pnpm)
 echo
 echo updating pnpm example to Cypress latest version


### PR DESCRIPTION
@PilotConway 

This ensures that your new example will get updated when new versions of Cypress or Yarn Modern are released.

The script is run manually.

You can either add this into your PR or I will do it separately when the next version of Cypress is released.

I noticed that Yarn is now up to `3.5.1` (released 3 days ago) when I tested the script. You don't need to update your example to this version though. It's fine to leave it using `3.5.0` for the time being.